### PR TITLE
feat #2 - [캘린더] 일정 조회

### DIFF
--- a/src/apis/CalendarAPICalls.js
+++ b/src/apis/CalendarAPICalls.js
@@ -1,4 +1,4 @@
-import { GET_CALENDAR } from "../modules/CalendarModule";
+import { GET_CALENDAR, POST_CALENDAR } from "../modules/CalendarModule";
 import axios from 'axios';
 
 const API_BASE_URL = 'http://localhost:8080';
@@ -7,20 +7,32 @@ const headers = {
     'Content-Type': 'application/json; charset=UTF-8',
     Accept: '*/*',
     Authorization: 'Bearer ' + window.localStorage.getItem('accessToken'),
-  };
+};
 
-export const callInsertCalendarAPI = async (requestData) => {
-    console.log('callInsertCalendarAPI [requestData]: ', requestData)
 
-    try {
-        console.log('axios 실행 전')
-        const response = await axios.post(`${API_BASE_URL}/calendars`, requestData, { headers })
-        console.log('[response]: ', response);
-        console.log('[response]: ', response.data);
-        return response.data;
-    } catch (error) {
-        console.error('일정 추가에 문제가 있습니다:', error);
+export const callSelectCalendarAPI = (department) => {
+    return async (dispatch) => {
+        try {
+            const response = await axios.get(`${API_BASE_URL}/calendars?department=${department}`, { headers });
 
+            dispatch({ type: GET_CALENDAR, payload: response.data.results });
+
+        } catch (error) {
+            console.log('일정 조회에 문제 발생', error);
+        }
+    };
+};
+
+export const callInsertCalendarAPI = (requestData) => {
+    return async (dispatch) => {
+        try {
+            const response = await axios.post(`${API_BASE_URL}/calendars`, requestData, { headers })
+
+            dispatch({ type: POST_CALENDAR, payload: response.data });
+
+        } catch (error) {
+            console.error('일정 추가에 문제가 있습니다:', error);
+        }
     }
 
 };

--- a/src/modules/CalendarModule.js
+++ b/src/modules/CalendarModule.js
@@ -15,8 +15,8 @@ const actions = createActions({
 });
 
 const calendarReducer = handleActions({
-    [GET_CALENDAR]: (state, {payload}) => {},
-    [POST_CALENDAR]: (state, {payload}) => {},
+    [GET_CALENDAR]: (state, {payload}) => ({calendarList: payload.calendarList}),
+    [POST_CALENDAR]: (state, {payload}) => ({insertMessage: payload}),
     [PUT_CALENDAR]: (state, {payload}) => {},
     [DELETE_CALENDAR]: (state, {payload}) => {}
 }, initialState);

--- a/src/pages/calendar/Calendar.jsx
+++ b/src/pages/calendar/Calendar.jsx
@@ -7,18 +7,18 @@ import koLocale from '@fullcalendar/core/locales/ko';
 import './Calendar.css';
 import "bootstrap/dist/css/bootstrap.min.css";
 import Modal from './Modal';
-import { callInsertCalendarAPI } from '../../apis/CalendarAPICalls';
-
+import { callInsertCalendarAPI, callSelectCalendarAPI } from '../../apis/CalendarAPICalls';
+import { useSelector, useDispatch } from 'react-redux';
+import '../../css/common.css'
 
 
 function Calendar() {
 
-    const pageTitleStyle = {
-        marginBottom: '20px',
-        marginTop: '20px'
-    };
-
+    const { calendarList, insertMessage } = useSelector(state => state.calendarReducer)
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [events, setEvents] = useState([]);
+    const dispatch = useDispatch();
+
 
     const handleOpenModal = () => {
         setIsModalOpen(true);
@@ -30,55 +30,60 @@ function Calendar() {
 
     const handleSaveChanges = ({ title, start, end, color }) => {
         const requestData = {
-            calendarStart : start,
-            calendarEnd : end,
-            calendarName : title,
+            calendarStart: start,
+            calendarEnd: end,
+            calendarName: title,
             color,
-            department : "개발팀", // TODO: 나중에 부서 선택해서 추가하는 기능넣어야 함
-            registrantId : 200401023 // TODO: 나중에 관리자 사번 뽑아서 넣는 걸로 바꿔야 함
+            department: "개발팀", // TODO: 나중에 부서 선택해서 추가하는 기능넣어야 함
+            registrantId: 200401023 // TODO: 나중에 관리자 사번 뽑아서 넣는 걸로 바꿔야 함
         };
-        console.log('[requestData]: ', requestData)
-        callInsertCalendarAPI(requestData)
+        dispatch(callInsertCalendarAPI(requestData));
 
     };
 
 
     useEffect(() => {
-        const handleEventDidMount = (info) => {
-            // 이벤트가 마운트될 때 실행되는 코드를 작성합니다.
-        };
+        const department = "개발팀"; // TODO: 나중에 부서 선택해서 추가하는 기능넣어야 함
+        dispatch(callSelectCalendarAPI(department));
 
-        // 컴포넌트가 마운트될 때 FullCalendar의 eventDidMount 이벤트에 이벤트 핸들러를 등록합니다.
-        return () => {
-            // 컴포넌트가 언마운트될 때 이벤트 핸들러를 해제합니다.
-        };
     }, []);
 
-    const events = [
-        {
-            title: 'test1',
-            start: '2024-05-01T08:00:00',
-            end: '2024-05-02T09:00:00',
-            color: 'red'
-        },
-        {
-            title: 'test2',
-            start: '2024-05-01T08:00:00',
-            end: '2024-05-02T09:00:00',
-            color: 'blue'
-        },
-        {
-            title: 'test3',
-            start: '2024-05-03T07:30:00',
-            end: '2024-05-04T09:00:00',
-            color: 'green'
+    useEffect(() => {
+        const department = "개발팀"; // TODO: 나중에 부서 선택해서 추가하는 기능넣어야 함
+        dispatch(callSelectCalendarAPI(department));
+
+    }, [insertMessage]);
+
+    useEffect(() => {
+        if (calendarList) {
+            const newEvents = calendarList.map(calendar => {
+                // Javascript date 타입의 month 가 0~11 db에 저장된 월에서 1을 빼줘야 정상적으로 표현됨
+                calendar.calendarStart[1] = calendar.calendarStart[1] - 1;
+                calendar.calendarEnd[1] = calendar.calendarEnd[1] - 1;
+
+                // 배경이 노랑이면 흰색글씨가 안보여서 노랑일 때 글씨색 변경
+                let textColor = 'white';
+                if (calendar.color === 'yellow') {
+                    textColor = 'black'; // 
+                }
+
+                return {
+                    calendarNo: calendar.calendarNo,
+                    title: calendar.calendarName,
+                    start: calendar.calendarStart,
+                    end: calendar.calendarEnd,
+                    color: calendar.color,
+                    textColor: textColor
+                }
+            });
+            setEvents(newEvents);
         }
-    ];
+    }, [calendarList]);
 
 
     return <>
         <main id="main" className="main">
-            <div className="pagetitle" style={pageTitleStyle}>
+            <div className="pagetitle">
                 <h1>캘린더</h1>
                 <nav>
                     <ol className="breadcrumb">


### PR DESCRIPTION
> 마운트 시 db에 있는 정보를 모두 조회해서 events 객체에 배열로 담아 일정을 출력할 수 있게 하였습니다.
> javascript date 에서 month 는 0~11 이라 db에서 조회해온 값을 변환할 때 month 정보가 맞지 않아 조회해온 일정의 month 부분에서 1을 빼서 형식을 맞췄습니다.
> 기존에는 등록이 됐을 때 조회 후 반환된 데이터를 사용하지 않았는데, 등록이 될 때마다 조회가 되게 하기 위해 등록이 됐을 떄 calendarReducer에 반환된 데이터를 저장하게 하여 등록시 calendarReducer의 insertMessage의 값이 변할 때마다 조회를 해올 수 있게 구현하였습니다.
