### PR TITLE
fix #8 - [출퇴근] 출퇴근 조회 시, 출퇴근 데이터가 없는 지나간 날짜의 정정 요청 버튼 렌더링 되지 않는 문제

### DIFF
--- a/src/components/commutes/CommuteItem.js
+++ b/src/components/commutes/CommuteItem.js
@@ -149,15 +149,15 @@ function CommuteItem({ commute, tableStyles, evenRow, date }) {
 
     return (
         <tr style={evenRow ? tableStyles.evenRow : {}}>
-            <td style={tableStyles.tableCell1}>{formatWorkingDate(commute.workingDate)}</td>
-            <td style={tableStyles.tableCell2}>{formatTotalWorkingHours(commute.totalWorkingHours)}</td>
-            <td style={tableStyles.tableCell3}>{formatWorkingTime(commute.startWork)}</td>
-            <td style={tableStyles.tableCell4}>{formatWorkingTime(commute.endWork)}</td>
-            <td style={tableStyles.tableCell5}><ProgressBar startTime={commute.startWork} endTime={commute.endWork} /></td>
-            <td style={tableStyles.tableCell6}>{commute.workingStatus}</td>
-            <td style={tableStyles.tableCell7}><button to="/" style={insertCorrection}>정정</button></td>
+          <td style={tableStyles.tableCell1}>{formatWorkingDate(commute.workingDate || '')}</td>
+          <td style={tableStyles.tableCell2}>{formatTotalWorkingHours(commute.totalWorkingHours || 0)}</td>
+          <td style={tableStyles.tableCell3}>{formatWorkingTime(commute.startWork || [])}</td>
+          <td style={tableStyles.tableCell4}>{formatWorkingTime(commute.endWork || [])}</td>
+          <td style={tableStyles.tableCell5}><ProgressBar startTime={commute.startWork || []} endTime={commute.endWork || []} /></td>
+          <td style={tableStyles.tableCell6}>{commute.workingStatus || '미출근'}</td>
+          <td style={tableStyles.tableCell7}><button to="/" style={insertCorrection}>정정</button></td>
         </tr>
-    );
+      );
 }
 
 export default CommuteItem;

--- a/src/components/commutes/CommuteListByMember.js
+++ b/src/components/commutes/CommuteListByMember.js
@@ -63,6 +63,28 @@ function CommuteListByMember({ commute, date }) {
         }
     };
 
+    const formatWorkingDate = (workingDate) => {
+        const dateObj = new Date(workingDate);
+        return `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, '0')}-${String(dateObj.getDate()).padStart(2, '0')}`;
+    };
+
+    const generateDates = () => {
+        const dates = [];
+        const startDate = new Date(date.getFullYear(), date.getMonth(), date.getDate() - (date.getDay() ? date.getDay() - 1 : 6));  // 이번 주 월요일
+        const endDate = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() + 6);                           // 이번 주 일요일
+
+        console.log('시작 날짜 : ', startDate);
+        console.log('종료 날짜 : ', endDate);
+
+        while (startDate <= endDate) {
+            const formattedDate = formatWorkingDate(startDate);
+            dates.push(formattedDate);
+            startDate.setDate(startDate.getDate() + 1);
+        }
+
+        return dates;
+    };
+
     return (
         <div className="col-lg-12">
             <div className="card">
@@ -79,7 +101,7 @@ function CommuteListByMember({ commute, date }) {
                                 <th style={tableStyles.tableHeaderCell} scope="col">정정 요청</th>
                             </tr>
                         </thead>
-                        <tbody>
+                        {/* <tbody>
                             {commute && commute.length > 0 ? (
                                 commute.map((item, index) => (
                                     <CommuteItem key={item.commuteNo} commute={item} tableStyles={tableStyles} evenRow={index % 2 === 0} date={date} />
@@ -89,6 +111,22 @@ function CommuteListByMember({ commute, date }) {
                                     <td colSpan={7}>출퇴근 내역이 없습니다.</td>
                                 </tr>
                             )}
+                        </tbody> */}
+                        <tbody>
+                            {generateDates().map((dateItem, index) => {
+                                const matchingCommute = commute.find(
+                                    (item) => formatWorkingDate(item.workingDate) === dateItem
+                                );
+                                return (
+                                    <CommuteItem
+                                        key={`${dateItem}-${index}`}
+                                        commute={matchingCommute || { workingDate: dateItem }}
+                                        tableStyles={tableStyles}
+                                        evenRow={index % 2 === 0}
+                                        date={date}
+                                    />
+                                );
+                            })}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
출퇴근 조회 시, 출퇴근 데이터가 없는 지나간 날짜의 정정 요청 버튼 렌더링 되지 않는 문제 해결하였습니다.