### PR TITLE
feat #3 - [수요조사] 수요조사 등록

### DIFF
--- a/src/apis/SurveyAPICalls.js
+++ b/src/apis/SurveyAPICalls.js
@@ -1,6 +1,6 @@
 import { } from "../modules/LeaveModule";
 import axios from 'axios';
-import { GET_PAGE } from "../modules/SurveyModule";
+import { GET_PAGE, POST_MESSAGE } from "../modules/SurveyModule";
 
 const API_BASE_URL = 'http://localhost:8080';
 
@@ -25,3 +25,28 @@ export const callSelectSurveyListAPI = (number, properties, direction, memberId)
         }
     }
 };
+
+export const callInsertSurveyResponse = requestData => {
+    return async dispatch => {
+        try {
+        const response = await axios.post(`${API_BASE_URL}/surveyResponses`, requestData, { headers });
+
+            dispatch({ type: POST_MESSAGE, payload: response.data})
+        } catch {
+            console.log('수요조사 응답 등록에 문제 발생', Error);
+        }
+    }
+}
+
+export const callInsertSurvey = requestData => {
+    return async dispatch => {
+        console.log('[requestData]',requestData);
+        try {
+        const response = await axios.post(`${API_BASE_URL}/surveys`, requestData, { headers });
+console.log(response.data);
+            dispatch({ type: POST_MESSAGE, payload: response.data})
+        } catch {
+            console.log('수요조사 응답 등록에 문제 발생', Error);
+        }
+    }
+}

--- a/src/css/survey/SurveyInsertModal.css
+++ b/src/css/survey/SurveyInsertModal.css
@@ -1,0 +1,36 @@
+
+.surveyInsertTextarea {
+    width: 100%;
+    box-sizing: border-box;
+    resize: none; 
+    overflow: hidden;
+}
+
+.surveyInsert {
+    display: flex;
+    height: 57.65px;
+}
+
+.surveyInsert > label {
+    height: 24px;
+    margin-top: 1.6%;
+}
+
+.surveyInsert input[type="text"] {
+    width: 202.4px;
+    height: 37.65px;
+}
+
+.surveyInsert label {
+    margin-right: 11px;
+}
+
+.surveyAnswer {
+    width: 80% !important;
+    display: inline;
+}
+
+.addAnswer {
+    margin-left: 2%;
+    cursor: pointer;
+}

--- a/src/modules/SurveyModule.js
+++ b/src/modules/SurveyModule.js
@@ -4,10 +4,16 @@ const initialState = {};
 
 export const GET_PAGE = 'survey/GET_PAGE';
 export const SET_PAGENUMBER = 'survey/SET_PAGENUMBER';
+export const POST_MESSAGE = 'survey/POST_MESSAGE';
+export const PUT_MESSAGE = 'survey/PUT_MESSAGE';
+export const DELETE_MESSAGE = 'survey/DELETE_MESSAGE';
 
 const actions = createActions({
     [GET_PAGE]: () => {},
     [SET_PAGENUMBER]:() => {},       
+    [POST_MESSAGE]: () => {},
+    [PUT_MESSAGE]: () => {},
+    [DELETE_MESSAGE]: () => {},
 });
 
 const surveyReducer = handleActions({
@@ -19,6 +25,10 @@ const surveyReducer = handleActions({
             number: payload
         }
     }),
+    [POST_MESSAGE]: (state, {payload}) => ({insertMessage: payload}),
+    [PUT_MESSAGE]: (state, {payload}) => ({updateMessage: payload}),
+    [DELETE_MESSAGE]: (state, {payload}) => ({deleteMessage: payload}),
+
 }, initialState);
 
 export default surveyReducer;

--- a/src/pages/survey/SurveyInsertModal.js
+++ b/src/pages/survey/SurveyInsertModal.js
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+import '../../css/survey/SurveyInsertModal.css'
+
+function SurveyInsertModal({ isOpen, onClose, onSave, name }) {
+    const [title, setTitle] = useState('');
+    const [start, setStart] = useState('');
+    const [end, setEnd] = useState('');
+    const [answers, setAnswer] = useState([]);
+
+    const handleSurveyInsert = () => {
+        // 배열 안에 있는 모든 빈문자열을 제거
+        const answerFilter = answers.filter(answer => answer !== '');
+        onSave({ title, start, end, answerFilter })
+        onClose();
+    }
+
+    const resetModal = () => {
+        setTitle('');
+        setStart('');
+        setEnd('');
+        setAnswer(['']);
+    };
+
+    // 답변 입력창이 생성될 때마다 빈문자열을 추가해 인덱스 확보
+    const addAnswer = () => {
+        if (answers.length < 5) {
+            setAnswer(prevAnswers => [...prevAnswers, '']);
+        }
+    };
+
+    // index를 함께 받아 생성된 모든 답변에 대해 수정이 가능
+    const handleAnswerChange = (index, value) => {
+        const newAnswers = [...answers];
+        newAnswers[index] = value;
+        setAnswer(newAnswers);
+    };
+
+    // 해당 답변 입력창과 답변 삭제
+    const removeAnswer = (selectedIndex) => {
+        setAnswer(prevAnswers => prevAnswers.filter((answer, index) => index !== selectedIndex));
+    };
+
+    // 모달이 열릴 때 초기화
+    useEffect(() => {
+        if (isOpen) {
+            resetModal();
+        }
+    }, [isOpen]);
+
+    return (
+        isOpen && (
+            <div className="modal fade show" style={{ display: 'block' }}>
+                <div className="modal-dialog">
+                    <div className="modal-content">
+                        <div className="modal-header">
+                            <h5 className="modal-title">수요조사 등록</h5>
+                        </div>
+                        <div className="modal-body">
+
+                            <div>
+                                <label>제목</label>
+                                <textarea value={title} onChange={e => setTitle(e.target.value)} className="form-control surveyInsertTextarea" rows={1}
+                                    onInput={(e) => {
+                                        e.target.style.height = 'auto';
+                                        e.target.style.height = (e.target.scrollHeight) + 'px';
+                                    }} />
+                            </div>
+
+                            <div className="surveyInsert"><label>작성자</label><input type="text" value={name} className="form-control surveyWriter" disabled /></div>
+
+                            <div className="form-group">
+                                <label>수요조사 기간</label>
+                                <div className='dateFlex'>
+                                    <DatePicker selected={start} onChange={e => setStart(e)} dateFormat="yyyy-MM-dd" className="form-control" />
+                                    <span>-</span>
+                                    <DatePicker selected={end} onChange={e => setEnd(e)} dateFormat="yyyy-MM-dd" className="form-control" />
+                                </div>
+                            </div>
+
+                            <label>수요조사 답변</label>
+                            <div className="border p-3">
+                                {answers.map((answer, index) => (
+                                    <div key={index}>
+                                        {/*  단축평가를 통해 답변 생성 버튼은 답변이 5개 생성 시  보이지 않으며, 마지막 답변에만 보이고 추가 버튼이 생기지 않으면 삭제 버튼이 보임*/}
+                                        <input value={answer} onChange={(e) => handleAnswerChange(index, e.target.value)} className="surveyAnswer form-control" />
+                                        {index === answers.length - 1 && index < 4 && <i className="ri ri-add-fill addAnswer" onClick={addAnswer}></i>
+                                            || <i className="ri-close-fill addAnswer" onClick={() => removeAnswer(index)}></i>}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <div className="modal-footer">
+                            <button type="button" className="btn btn-secondary" onClick={onClose}>취소</button>
+                            <button type="button" className="btn btn-primary" onClick={handleSurveyInsert}>제출</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
+    );
+}
+
+export default SurveyInsertModal;

--- a/src/pages/survey/SurveyList.js
+++ b/src/pages/survey/SurveyList.js
@@ -1,23 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
-import { callSelectSurveyListAPI } from '../../apis/SurveyAPICalls';
+import { callInsertSurvey, callInsertSurveyResponse, callSelectSurveyListAPI } from '../../apis/SurveyAPICalls';
 import { SET_PAGENUMBER } from '../../modules/SurveyModule';
+import SurveyModal from './SurveyModal';
 import { decodeJwt } from '../../utils/tokenUtils';
 import { renderSurveyList } from '../../utils/SurveyUtil';
-import '../../css/survey/surveyList.css'
+import '../../css/survey/SurveyList.css'
 import '../../css/common.css'
+import SurveyInsertModal from './SurveyInsertModal';
 
 
 function SurveyList() {
     const { page } = useSelector(state => state.surveyReducer);
     const { number, content, totalPages } = page || {};
-    const [ properties, setProperties ] = useState('surveyNo');
-    const [ direction, setDirection ] = useState('DESC');
-    const [ isModalOpen, setIsModalOpen ] = useState(false);
-    const [ isLoading, setIsLoading ] = useState(false);
+    const [properties, setProperties] = useState('surveyNo');
+    const [direction, setDirection] = useState('DESC');
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [isInsertModalOpen, setIsInsertModalOpen] = useState(false);
+    const [survey, setServey] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
 
     const memberId = decodeJwt(window.localStorage.getItem("accessToken")).memberId;
+    const name = decodeJwt(window.localStorage.getItem("accessToken")).name;
 
     const dispatch = useDispatch();
 
@@ -41,91 +46,131 @@ function SurveyList() {
         setDirection(direction === 'DESC' ? 'ASC' : 'DESC');
     }
 
+    // CUD 관련 핸들러
     const handleOpenModal = () => {
         setIsModalOpen(true);
     };
 
-    const handleCloseModal = () => {
-        setIsModalOpen(false);
+    const handleInsertOpenModal = () => {
+        setIsInsertModalOpen(true);
     };
 
-  useEffect(() => {
+    const handleCloseModal = () => {
+        setIsModalOpen(false);
+        setIsInsertModalOpen(false);
+    };
+
+    const handleInsertResponse = response => {
+        const requestData = {
+            surveyAnswer: response,
+            memberId
+        };
+        dispatch(callInsertSurveyResponse(requestData));
+    };
+
+    const handleInsertSurvey = ({ title, start, end, answerFilter }) => {
+        const requestData = {
+            surveyDTO: {
+                surveyTitle: title,
+                surveyStartDate: start,
+                surveyEndDate: end,
+                memberId
+            },
+            answers: answerFilter
+        };
+        console.log(requestData);
+        dispatch(callInsertSurvey(requestData));
+    };
+
+    useEffect(() => {
         setIsLoading(true);
         dispatch(callSelectSurveyListAPI(number, properties, direction, memberId))
             .finally(() => setIsLoading(false));
     }, [number, properties, direction]);
 
 
-    return <main id="main" className="main">
-     <div className="pagetitle">
-            <h1>수요조사</h1>
-            <nav>
-                <ol className="breadcrumb">
-                    <li className="breadcrumb-item"><Link to="/">Home</Link></li>
-                </ol>
-            </nav>
-        </div>
-        <div className="col-lg-12">
-            <div className="card">
-                <div className="surveyListContent" >
-                    <table className="table table-hover">
-                        <thead>
-                            <tr>
-                                <th onClick={() => handleSort('surveyNo')}>
-                                    <span>번호</span><i className="bx bxs-sort-alt"></i>
-                                </th>
-
-                                <th onClick={() => handleSort('surveyTitle')} style={{width: '20%'}}>
-                                    <span>제목</span><i className="bx bxs-sort-alt"></i>
-                                </th>
-
-                                <th><span>시작 일자</span></th>
-
-                                <th><span>마감 일자</span></th>
-
-                                <th><span>작성자</span></th>
-
-                                <th><span></span></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {isLoading ? ( // 로딩 중이면 로딩 메시지 표시
-                                <tr>
-                                    <td colSpan="6" className="loadingText"></td>
-                                </tr>
-                            ) : (
-                                renderSurveyList(content, handleOpenModal) // 로딩 중이 아니면 실제 데이터 표시
-                            )}
-                        </tbody>
-                    </table>
-
-                    <nav >
-                        <ul className="pagination">
-
-                            <li className={`page-item ${number === 0 && 'disabled'}`}>
-                                <button className="page-link" onClick={handlePrevPage}>◀</button>
-                            </li>
-
-                            {[...Array(totalPages).keys()].map((page, index) => (
-                                <li key={index} className={`page-item ${number === page && 'active'}`}>
-                                    <button className="page-link" onClick={() => {
-                                        console.log('[page]', page);
-                                        handlePageChange(page)
-                                    }}>
-                                        {page + 1}
-                                    </button>
-                                </li>
-                            ))}
-
-                            <li className={`page-item ${number === totalPages - 1 && 'disabled'}`}>
-                                <button className="page-link" onClick={handleNextPage}>▶</button>
-                            </li>
-                        </ul>
-                    </nav>
+    return <>
+        <main id="main" className="main">
+            <div className="pagetitle">
+                <h1>수요조사</h1>
+                <nav>
+                    <ol className="breadcrumb">
+                        <li className="breadcrumb-item"><Link to="/">Home</Link></li>
+                    </ol>
+                </nav>
+                <div className="leaveHeader">
+                    <div> </div>
+                    <span className="insertSurvey" onClick={handleInsertOpenModal} >수요조사 등록</span>
                 </div>
             </div>
-        </div>
-    </main>
+            <div className="col-lg-12">
+                <div className="card">
+                    <div className="surveyListContent" >
+                        <table className="table table-hover">
+                            <thead>
+                                <tr>
+                                    <th onClick={() => handleSort('surveyNo')}>
+                                        <span>번호</span><i className="bx bxs-sort-alt"></i>
+                                    </th>
+
+                                    <th onClick={() => handleSort('surveyTitle')} style={{ width: '20%' }}>
+                                        <span>제목</span><i className="bx bxs-sort-alt"></i>
+                                    </th>
+
+                                    <th><span>시작 일자</span></th>
+
+                                    <th><span>마감 일자</span></th>
+
+                                    <th><span>작성자</span></th>
+
+                                    <th><span></span></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {
+                                    // 로딩 중이면 로딩 메시지 표시
+                                    isLoading ? (
+                                        <tr>
+                                            <td colSpan="6" className="loadingText"></td>
+                                        </tr>
+                                    ) : (
+                                        // 로딩 중이 아니면 실제 데이터 표시
+                                        renderSurveyList(content, handleOpenModal, setServey)
+                                    )}
+                            </tbody>
+                        </table>
+
+                        <nav >
+                            <ul className="pagination">
+
+                                <li className={`page-item ${number === 0 && 'disabled'}`}>
+                                    <button className="page-link" onClick={handlePrevPage}>◀</button>
+                                </li>
+
+                                {[...Array(totalPages).keys()].map((page, index) => (
+                                    <li key={index} className={`page-item ${number === page && 'active'}`}>
+                                        <button className="page-link" onClick={() => {
+                                            console.log('[page]', page);
+                                            handlePageChange(page)
+                                        }}>
+                                            {page + 1}
+                                        </button>
+                                    </li>
+                                ))}
+
+                                <li className={`page-item ${number === totalPages - 1 && 'disabled'}`}>
+                                    <button className="page-link" onClick={handleNextPage}>▶</button>
+                                </li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
+            </div>
+        </main>
+        <SurveyModal isOpen={isModalOpen} onClose={handleCloseModal} onSave={handleInsertResponse} survey={survey} />
+        <SurveyInsertModal isOpen={isInsertModalOpen} onClose={handleCloseModal} onSave={handleInsertSurvey} name={name} />
+
+    </>
 }
 
 export default SurveyList;


### PR DESCRIPTION
> 수요조사 등록 시 최대 5개까지 작성자가 답변의 개수를 늘릴 수 있도록 구현하였습니다.
> 수요조사 제목 입력 시 길이가 화면을 넘어가게 되면 줄바꿈과 동시에 textarea의 높이가 자동으로 변경됩니다.
> 답변 옆에 + 버튼을 누르면 아래에 입력창이 하나 더 생기게 되고 state인 answer에 빈문자열을 추가해 최대 5개까지 배열의 길이를 증가시킵니다.
> 각 답변 입력창에 값을 입력하면 onChange 이벤트를 통해 해당 index에 맞는 배열의 값을 변경합니다.
> 답변 입력창 옆 -를 누르면 해당 입력창을 삭제함과 동시에 답변 입력창에 해당하던 answer의 인덱스 값도 삭제하여 보여지는 입력창과 answer의 배열 순서를 일치시킵니다.
> 답변 입력창 옆 + 와 - 는 단축평가를 통해 + 버튼은 가장 마지막 답변 입력창 옆에만 표시되며,  답변 입력창이 5개 미만일 때만 표시되게 만들어 답변 입력창이 5개가 되면 +버튼이 보이지 않도록 하였습니다.
> - 버튼은 단축평가를 통해 + 버튼이 나오지 않았을 경우에만 표시되게 구현하여 최적화를 진행하였습니다.