### PR TITLE
fix #3 - [휴가] 페이지 첫 렌더링 시 렌더링 반복

### DIFF
--- a/src/pages/leave/LeaveAccrual.js
+++ b/src/pages/leave/LeaveAccrual.js
@@ -73,7 +73,8 @@ function LeaveAccrual() {
                 setIsLoading(false);
             }
         };
-        fetchData();
+        number !== undefined 
+            && fetchData();
     }, [number, properties, direction]);
 
     return <main id="main" className="main">

--- a/src/pages/leave/LeaveProcessing.js
+++ b/src/pages/leave/LeaveProcessing.js
@@ -63,20 +63,25 @@ function LeaveProcessing() {
     }
 
     useEffect(() => {
+        console.log('빈배열 유즈이펙트');
         const resetNumber = async () => await dispatch({ type: SET_PAGENUMBER, payload: 0 })
         resetNumber();
     }, []);
 
     useEffect(() => {
+        console.log(number);
+        console.log('유즈이펙트 진입');
         setIsLoading(true);
         const fetchData = async () => {
             try {
+                console.log('디스패치 실행');
                 await dispatch(callSelectLeaveSubmitAPI(number, properties, direction));
             } finally {
                 setIsLoading(false);
             }
         };
-        fetchData();
+        number !== undefined 
+            && fetchData();
     }, [number, properties, direction]);
 
     return <main id="main" className="main">

--- a/src/pages/leave/Leaves.js
+++ b/src/pages/leave/Leaves.js
@@ -50,7 +50,8 @@ function Leaves() {
                 setIsLoading(false);
             }
         };
-        fetchData()
+        number !== undefined 
+            && fetchData();
     }, [number, properties, direction]);
 
     return <main id="main" className="main">

--- a/src/pages/leave/MyLeave.js
+++ b/src/pages/leave/MyLeave.js
@@ -90,7 +90,8 @@ function MyLeave() {
                 setIsLoading(false);
             }
         };
-        fetchData();
+        number !== undefined 
+            && fetchData();
     }, [number, properties, direction, insertMessage]);
 
     return <main id="main" className="main">


### PR DESCRIPTION
> 의존성 배열이 빈 배열인 useEffect를 이용해 첫 화면 렌더링 시 페이지 넘버를 0으로 초기화 하도록 로직을 구현했는데, 이게 페이지 넘버가 바뀔 때마다 휴가 내역 조회를 수행하는 useEffect와 충돌을 일으킨 것으로 확인 되었습니다.
> 단축평가를 활용해 하여 휴가 내역을 불러오는 비동기 통신이  페이지 넘버가 undefined 일 때 수행되지 않게 하였습니다.
> 이제 정상적으로 페이지 넘버에 0이 들어간 이후부터 내역을 불러오도록 수정하여 해당 버그가 발생하지 않습니다.