### PR TITLE
fix #4 - [휴가] 휴가 페이징 오류 재수정

### DIFF
--- a/src/pages/leave/LeaveAccrual.js
+++ b/src/pages/leave/LeaveAccrual.js
@@ -16,6 +16,7 @@ function LeaveAccrual() {
     const [direction, setDirection] = useState('DESC');
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
+    const [isReset, setIsReset] = useState(false);
     const memberId = decodeJwt(window.localStorage.getItem("accessToken")).memberId;
 
     const dispatch = useDispatch();
@@ -60,7 +61,13 @@ function LeaveAccrual() {
     };
 
     useEffect(() => {
-        const resetNumber = async () => await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+        const resetNumber = async () => {
+            try {
+                await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+            } finally {
+                setIsReset(true);
+            }
+        }
         resetNumber();
     }, []);
 
@@ -73,10 +80,9 @@ function LeaveAccrual() {
                 setIsLoading(false);
             }
         };
-        number !== undefined 
+        isReset
             && fetchData();
-    }, [number, properties, direction]);
-
+    }, [number, properties, direction, isReset]);
     return <main id="main" className="main">
         <div className="pagetitle">
             <h1>휴가</h1>

--- a/src/pages/leave/LeaveProcessing.js
+++ b/src/pages/leave/LeaveProcessing.js
@@ -18,6 +18,7 @@ function LeaveProcessing() {
     const [leaveSubNo, setLeaveSubNo] = useState('');
     const [selectedTime, setSelectedTime] = useState('');
     const [detailInfo, setDetailInfo] = useState('');
+    const [isReset, setIsReset] = useState(false);
 
     const dispatch = useDispatch();
 
@@ -63,26 +64,28 @@ function LeaveProcessing() {
     }
 
     useEffect(() => {
-        console.log('빈배열 유즈이펙트');
-        const resetNumber = async () => await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+        const resetNumber = async () => {
+            try {
+                await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+            } finally {
+                setIsReset(true);
+            }
+        }
         resetNumber();
     }, []);
 
     useEffect(() => {
-        console.log(number);
-        console.log('유즈이펙트 진입');
         setIsLoading(true);
         const fetchData = async () => {
             try {
-                console.log('디스패치 실행');
                 await dispatch(callSelectLeaveSubmitAPI(number, properties, direction));
             } finally {
                 setIsLoading(false);
             }
         };
-        number !== undefined 
+        isReset
             && fetchData();
-    }, [number, properties, direction]);
+    }, [number, properties, direction, isReset]);
 
     return <main id="main" className="main">
         <div className="pagetitle">

--- a/src/pages/leave/Leaves.js
+++ b/src/pages/leave/Leaves.js
@@ -13,6 +13,7 @@ function Leaves() {
     const [properties, setProperties] = useState('memberId')
     const [direction, setDirection] = useState('DESC')
     const [isLoading, setIsLoading] = useState(false);
+    const [isReset, setIsReset] = useState(false);
 
     const dispatch = useDispatch();
 
@@ -37,7 +38,13 @@ function Leaves() {
     }
 
     useEffect(() => {
-        const resetNumber = async () => await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+        const resetNumber = async () => {
+            try {
+                await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+            } finally {
+                setIsReset(true);
+            }
+        }
         resetNumber();
     }, []);
 
@@ -50,9 +57,9 @@ function Leaves() {
                 setIsLoading(false);
             }
         };
-        number !== undefined 
+        isReset
             && fetchData();
-    }, [number, properties, direction]);
+    }, [number, properties, direction, isReset]);
 
     return <main id="main" className="main">
         <div className="pagetitle">

--- a/src/pages/leave/MyLeave.js
+++ b/src/pages/leave/MyLeave.js
@@ -20,6 +20,7 @@ function MyLeave() {
     const [isLoading, setIsLoading] = useState(false);
     const [leaveSubNo, setLeaveSubNo] = useState('');
     const [selectedTime, setSelectedTime] = useState('');
+    const [isReset, setIsReset] = useState(false);
     const memberId = decodeJwt(window.localStorage.getItem("accessToken")).memberId;
     const dispatch = useDispatch();
 
@@ -77,7 +78,13 @@ function MyLeave() {
     };
 
     useEffect(() => {
-        const resetNumber = async () => await dispatch({ type: SET_PAGENUMBER, payload: 0 });
+        const resetNumber = async () => {
+            try {
+                await dispatch({ type: SET_PAGENUMBER, payload: 0 })
+            } finally {
+                setIsReset(true);
+            }
+        }
         resetNumber();
     }, []);
 
@@ -90,9 +97,9 @@ function MyLeave() {
                 setIsLoading(false);
             }
         };
-        number !== undefined 
+        isReset
             && fetchData();
-    }, [number, properties, direction, insertMessage]);
+    }, [number, properties, direction, isReset]);
 
     return <main id="main" className="main">
         <div className="pagetitle">


### PR DESCRIPTION
> 다른 휴가 페이지에서 넘어올 땐 페이지 넘버가 초기화되지 않은 상태라 페이지 넘버가 undefined이기 때문에 문제가 완전히 해결되지 않은 것을 확인했습니다.
> isReset이란 변수를 만들어서 isReset의 값이 true일 때만 내역 조회를 수행하게 구현하였습니다.
> isReset의 값은 의존성 배열이 빈배열인 useEffect 에서 페이지 넘버를 0으로 바꾸는 요청이 종료되었을 때 true로 바뀝니다.
> 이제 페이지 넘버가 0으로 초기화 되기 전까지 내역을 확인할 수 없고, 완전히 0으로 초기화가 된 후 진행될 수 있도록 코드를 수정하였습니다.